### PR TITLE
Added tooltip prop to ActionButton.Item

### DIFF
--- a/ActionButton.js
+++ b/ActionButton.js
@@ -108,11 +108,11 @@ export default class ActionButton extends Component {
           activeOpacity={0.85}
           onLongPress={this.props.onLongPress}
           onPress={() => {
-              this.props.onPress();
-              if (this.props.children) {
-                this.animateButton();
-              }
-            }}
+            this.props.onPress();
+            if (this.props.children) {
+              this.animateButton();
+            }
+          }}
         >
           <Animated.View
             style={
@@ -155,12 +155,12 @@ export default class ActionButton extends Component {
     return (
       <Animated.Text
         style={[styles.btnText,
-                {
-                  color: this.state.anim.interpolate({
-                    inputRange: [0, 1],
-                    outputRange: [this.props.buttonTextColor, this.props.btnOutRangeTxt]
-                  })
-                }]}>
+          {
+            color: this.state.anim.interpolate({
+              inputRange: [0, 1],
+              outputRange: [this.props.buttonTextColor, this.props.btnOutRangeTxt]
+            })
+          }]}>
         +
       </Animated.Text>
     );
@@ -181,6 +181,9 @@ export default class ActionButton extends Component {
 
     return (
       React.Children.map(this.props.children, (button, index) => {
+        const length = this.props.children.length;
+        const leftSide = index < length / 2 - 1;
+        const middle = length % 2 === 0 ? (index === (length / 2) || index === (length / 2) - 1) : index === (length / 2) - 0.5;
         return (
 
           <View
@@ -197,13 +200,15 @@ export default class ActionButton extends Component {
               btnColor={this.props.btnOutRange}
               {...button.props}
               onPress={() => {
-                  if (this.props.autoInactive) {
-                    this.timeout = setTimeout(() => {
-                      this.reset();
-                    }, 200);
-                  }
-                  button.props.onPress();
-                }}
+                if (this.props.autoInactive) {
+                  this.timeout = setTimeout(() => {
+                    this.reset();
+                  }, 200);
+                }
+                button.props.onPress();
+              }}
+              leftSide={leftSide}
+              middle={middle}
             />
           </View>
         );
@@ -222,12 +227,12 @@ export default class ActionButton extends Component {
         >
           <Animated.View
             style={
-              {
-                backgroundColor: this.props.bgColor,
-                opacity: this.state.anim,
-                flex: 1,
-              }
-                  }
+            {
+              backgroundColor: this.props.bgColor,
+              opacity: this.state.anim,
+              flex: 1,
+            }
+            }
           >
             {this.props.backdrop}
           </Animated.View>

--- a/ActionButtonItem.js
+++ b/ActionButtonItem.js
@@ -7,55 +7,109 @@ import {
   View,
   Animated,
   TouchableOpacity,
+  Text
 } from 'react-native';
 
 export default class ActionButtonItem extends Component {
-
+  constructor(props) {
+    super(props);
+    this.state = {
+      tooltipWidth: 0
+    };
+    this.onLayout = this.onLayout.bind(this);
+  }
+  onLayout(event) {
+    this.setState({ tooltipWidth: event.nativeEvent.layout.width });
+  }
   render() {
     const offsetX = this.props.radius * Math.cos(this.props.angle);
     const offsetY = this.props.radius * Math.sin(this.props.angle);
+    const tooltipStyles = {
+      leftToolTip: {
+        position: 'absolute',
+        color: 'white',
+        minWidth: 80,
+        maxHeight: 17,
+        left: -this.state.tooltipWidth - 10,
+        top: 10,
+        textAlign: 'right'
+      },
+      middleToolTip: {
+        color: 'white',
+        position: 'absolute',
+        minWidth: 80,
+        maxHeight: 17,
+        top: -25,
+        left: (-this.state.tooltipWidth / 4) - 2,
+        alignSelf: 'center',
+        textAlign: 'center'
+      },
+      rightToolTip: {
+        color: 'white',
+        position: 'absolute',
+        minWidth: 80,
+        maxHeight: 17,
+        top: 10,
+        left: 45
+      }
+    };
     return (
       <Animated.View
         style={[{
-            opacity: this.props.anim,
-            width: this.props.size,
-            height: this.props.size,
-            transform: [
-              {
-                translateY: this.props.anim.interpolate({
-                  inputRange: [0, 1],
-                  outputRange: [0, offsetY],
-                }) },
-              {
-                translateX: this.props.anim.interpolate({
-                  inputRange: [0, 1],
-                  outputRange: [0, offsetX],
-                }) },
-              {
-                rotate: this.props.anim.interpolate({
-                  inputRange: [0, 1],
-                  outputRange: ['0deg', '720deg'],
-                }) },
-              {
-                scale: this.props.anim.interpolate({
-                  inputRange: [0, 1],
-                  outputRange: [0, 1],
-                }) },
-            ]
-          }]}
+          opacity: this.props.anim,
+          width: this.props.size,
+          height: this.props.size,
+          transform: [
+            {
+              translateY: this.props.anim.interpolate({
+                inputRange: [0, 1],
+                outputRange: [0, offsetY],
+              }) },
+            {
+              translateX: this.props.anim.interpolate({
+                inputRange: [0, 1],
+                outputRange: [0, offsetX],
+              }) },
+            {
+              rotate: this.props.anim.interpolate({
+                inputRange: [0, 1],
+                outputRange: ['0deg', '720deg'],
+              }) },
+            {
+              scale: this.props.anim.interpolate({
+                inputRange: [0, 1],
+                outputRange: [0, 1],
+              }) },
+          ]
+        }]}
       >
-        <TouchableOpacity style={{flex:1}} activeOpacity={this.props.activeOpacity || 0.85} onPress={this.props.onPress}>
+        {this.props.leftSide ?
+          <Text onLayout={this.onLayout} style={tooltipStyles.leftToolTip}>
+            {this.props.tooltip}
+          </Text> :
+          null
+        }
+        <TouchableOpacity style={{flex: 1}} activeOpacity={this.props.activeOpacity || 0.85} onPress={this.props.onPress}>
           <View
-            style={[styles.actionButton,{
-                width: this.props.size,
-                height: this.props.size,
-                borderRadius: this.props.size / 2,
-                backgroundColor: this.props.buttonColor,
-              }]}
+            style={[ styles.actionButton, {
+              width: this.props.size,
+              height: this.props.size,
+              borderRadius: this.props.size / 2,
+              backgroundColor: this.props.buttonColor
+            }]}
           >
             {this.props.children}
           </View>
         </TouchableOpacity>
+        {this.props.middle ?
+          <Text onLayout={this.onLayout} style={tooltipStyles.middleToolTip}>
+            {this.props.tooltip}
+          </Text> :
+          !this.props.leftSide ?
+            <Text style={tooltipStyles.rightToolTip}>
+              {this.props.tooltip}
+            </Text> : null
+        }
       </Animated.View>
     );
   }
@@ -68,6 +122,9 @@ ActionButtonItem.propTypes = {
   buttonColor: PropTypes.string,
   onPress: PropTypes.func,
   children: PropTypes.node.isRequired,
+  middle: PropTypes.bool,
+  leftSide: PropTypes.bool,
+  tooltip: PropTypes.string
 };
 
 ActionButtonItem.defaultProps = {
@@ -89,5 +146,5 @@ const styles = StyleSheet.create({
     shadowRadius: 1,
     backgroundColor: 'red',
     position: 'absolute',
-  },
+  }
 });

--- a/README.md
+++ b/README.md
@@ -100,3 +100,4 @@ Also this example uses `react-native-vector-icons` for the button Icons.
 | ------------- |:-------------:|:------------:       | ----------- |
 | onPress       | func          | null                | **required** function, triggers when a button is tapped
 | buttonColor   | string        | same as + button    | background color of the Button
+| tooltip       | string        | null                | text that is displayed next to the button


### PR DESCRIPTION
This pull request adds tooltips to the ActionButtonItem component. It calculates the position of each action button and either places it to the left, right or on top of the action button item.

Here are pictures of what the tooltip looks like with an even and odd set of ActionButtonItems.

<img width="376" alt="screen shot 2017-01-30 at 1 50 27 pm" src="https://cloud.githubusercontent.com/assets/14223893/22436771/72659ca0-e6f3-11e6-8aa1-6da10946635e.png">
<img width="376" alt="screen shot 2017-01-30 at 1 50 04 pm" src="https://cloud.githubusercontent.com/assets/14223893/22436774/737cf854-e6f3-11e6-8d01-d079be6a18ed.png">

@geremih Would you be interested in adding this to your project?