### PR TITLE
Switch PropTypes to external package

### DIFF
--- a/ActionButton.js
+++ b/ActionButton.js
@@ -1,6 +1,5 @@
 import React, {
   Component,
-  PropTypes,
 } from 'react';
 import {
   StyleSheet,
@@ -10,6 +9,7 @@ import {
   TouchableOpacity,
   TouchableWithoutFeedback,
 } from 'react-native';
+import PropTypes from 'prop-types';
 import ActionButtonItem from './ActionButtonItem';
 
 const alignMap = {

--- a/ActionButtonItem.js
+++ b/ActionButtonItem.js
@@ -1,6 +1,5 @@
 import React, {
   Component,
-  PropTypes,
 } from 'react';
 import {
   StyleSheet,
@@ -8,6 +7,7 @@ import {
   Animated,
   TouchableOpacity,
 } from 'react-native';
+import PropTypes from 'prop-types';
 
 export default class ActionButtonItem extends Component {
 

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   "bugs": {
     "url": "https://github.com/geremih/react-native-circular-action-menu/issues"
   },
-  "homepage": "https://github.com/geremih/react-native-circular-action-menu"
+  "homepage": "https://github.com/geremih/react-native-circular-action-menu",
+  "dependencies": {
+    "prop-types": "^15.6.1"
+  }
 }


### PR DESCRIPTION
Since React v15.5 PropTypes has been moved out into an external `prop-types` library, and using RN's PropTypes causes errors. See [here](https://reactjs.org/docs/typechecking-with-proptypes.html) for more details.